### PR TITLE
Issue #3: update the Edit action on the show page

### DIFF
--- a/app/controllers/peaches_controller.rb
+++ b/app/controllers/peaches_controller.rb
@@ -23,7 +23,7 @@ class PeachesController < ApplicationController
   def update
     @peach = Peach.find(params[:id])
     if @peach.update(peach_params)
-      redirect_to peaches_path
+      redirect_to peach_path
     else
       render 'edit'
     end

--- a/app/views/peaches/show.html.erb
+++ b/app/views/peaches/show.html.erb
@@ -2,3 +2,5 @@
 
 <p><%= @peach.name %> | <%= @peach.deadline %> days left</p>
 <%= button_to "Edit Peach", edit_peach_path(@peach), method: :get, id:"edit_peach" %>
+
+<p> Last updated: <%= time_ago_in_words(@peach.updated_at) %> ago</p>

--- a/spec/features/edit_peach_spec.rb
+++ b/spec/features/edit_peach_spec.rb
@@ -24,25 +24,25 @@ describe "edit a peach", :type => :feature do
     Peach.create(name: "learn testing", deadline: 5)
   end
 
-  it "user sees the edit a peach link" do
+  scenario "user sees the edit a peach link" do
     visit "/peaches/#{Peach.last.id}"
     expect(page).to have_css('#edit_peach')
   end
 
-  it "takes the user to the edit page when the user clicks the edit button" do
+  scenario "takes the user to the edit page when the user clicks the edit button" do
     visit "/peaches/#{Peach.last.id}"
     click_button('Edit Peach')
     expect(current_path).to eq("/peaches/#{Peach.last.id}/edit")
   end
 
-  it "updates the peach" do
+  scenario "updates the peach" do
     visit "/peaches/#{Peach.last.id}/edit"
     within(".edit_peach") do
       fill_in 'Name', with: 'drink less coffee'
       fill_in 'Deadline', with: 1
     end
     click_button('Update Peach')
-    expect(current_path).to eq("/peaches")
+    expect(current_path).to eq("/peaches/#{Peach.last.id}")
     # visit "/peaches"
     expect(page).to have_content("drink less coffee")
   end

--- a/spec/models/peach_spec.rb
+++ b/spec/models/peach_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe Peach, type: :model do
     expect(new_peach.name).to eq("Save the Rainforest")
     expect(new_peach.deadline).to eq(5)
   end
+  it "updates peach" do
+    new_peach = Peach.create!(name: "Save the Rainforest", deadline: 5)
+    new_peach.update(name:"Save the world", deadline: 6)
+
+    expect(new_peach.name).to eq("Save the world")
+    expect(new_peach.deadline).to eq(6)
+  end
 end


### PR DESCRIPTION
- Changed the redirect from index to show because it was
  confusing for the user.
- Added the updated time_ago on the show page  (inspired
  by Claudio's talk re: flash messages and UX): we decided
  to show user their peach is updated
